### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,4 @@
+name        := "libucontext"
+description := "A library which provides the <ucontext.h> API from older POSIX revisions."
+license     := "MIT"
+version     := 0.9.0 sha256:0d53a415a307ef175153bbe60a572c940a922cb736ce13530b666e7ec2795d68 http://distfiles.adelielinux.org/source/libucontext/libucontext-0.9.0.tar.xz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

